### PR TITLE
Add devcontainer configuration 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+    "name": "Groovy & Gradle Dev Container (1-8-jdk-bullseye)",
+    "image": "mcr.microsoft.com/devcontainers/java:1-8-jdk-bullseye",
+
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "8",
+            "installGradle": "true",
+            "gradleVersion": "5.0",
+            "installGroovy": "true",
+            "installMaven": "true"
+        }
+    },
+
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "vscjava.vscode-gradle",
+                "groovy-language.groovy",
+                "vscjava.vscode-java-pack"
+            ]
+        }
+    },
+    "postCreateCommand": "gradle --version && groovy --version"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,13 @@ apply plugin: 'maven-publish'
 // --------------------
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         url 'https://repo.jenkins-ci.org/public/'
+    }
+    maven {
+        // org.jfrog.artifactory.client:artifactory-java-client-services:1.2.2 is published here
+        url 'https://releases.jfrog.io/artifactory/oss-releases/'
     }
 }
 


### PR DESCRIPTION
This container uses old versions java, gradle etc. so this is simply so the code can opened as is
Naturally it should be adjusted to more recent versions of java, gradle and so forth, but that will be another day.